### PR TITLE
chore: Replace deprecated igraph calls with modern counterparts

### DIFF
--- a/R/asDF.R
+++ b/R/asDF.R
@@ -91,7 +91,7 @@ asDF.network <- function(object, ...)
 asDF.igraph <- function(object, ...)
 {
     # get edgelist
-    dfedge <- as.data.frame(igraph::get.edgelist(object, names=FALSE), 
+    dfedge <- as.data.frame(igraph::as_edgelist(object, names=FALSE), 
         stringsAsFactors=FALSE)
 	# add edge attributes, if any
     eattr <- dumpAttr(object, "edge")

--- a/R/asIgraph.R
+++ b/R/asIgraph.R
@@ -89,7 +89,7 @@ asIgraph.network <- function(x, amap=attrmap(), ...)
     if( length(na) > 0 )
     {
       for( naname in names(na) )
-        rval <- igraph::set.graph.attribute(rval, naname, na[[naname]])
+        rval <- igraph::set_graph_attr(rval, naname, na[[naname]])
     }
     rval
 }
@@ -101,16 +101,16 @@ asIgraph.network <- function(x, amap=attrmap(), ...)
 asIgraph.data.frame <- function(x, directed=TRUE, vertices=NULL, vnames=NULL, ...)
 {
     object <- x
-    rval <- igraph::graph.data.frame( object, directed=directed,
+    rval <- igraph::graph_from_data_frame( object, directed=directed,
         vertices=vertices)
     if(is.null(vnames))
     {
-      rval <- igraph::remove.vertex.attribute(rval, "name")
+      rval <- igraph::delete_vertex_attr(rval, "name")
     } else
     {
       if( !(vnames %in% names(vertices)) )
             stop("no column ", vnames, " in 'vertices'")
-      rval <- igraph::set.vertex.attribute(rval, "name", value=vertices[[vnames]])
+      rval <- igraph::set_vertex_attr(rval, "name", value=vertices[[vnames]])
     }
     rval
 }

--- a/R/asNetwork.R
+++ b/R/asNetwork.R
@@ -117,10 +117,10 @@ asNetwork.igraph <- function(x, amap=attrmap(), ...)
 
     ### make 'igraph' object
     rval <- asNetwork( edges,
-        directed=igraph::is.directed(object),
-        multiple = any(igraph::is.multiple(object)),
-        loops = any(igraph::is.loop(object)),
-        vertices=vertexes, ...)
+        directed = igraph::is_directed(object),
+        multiple = igraph::any_multiple(object),
+        loops = igraph::any_loop(object),
+        vertices = vertexes, ...)
 
     ### apply/rename/drop network attributes
     nats <- attrmapmat("igraph", "network", "network", db=amap)

--- a/R/dumpAttr.R
+++ b/R/dumpAttr.R
@@ -61,13 +61,13 @@ dumpAttr.igraph <- function(x, type=c("all", "network", "vertex", "edge"), ...)
 	} else
 	{
 		nams <- switch( type,
-			network = igraph::list.graph.attributes(x),
-			edge = igraph::list.edge.attributes(x),
-			vertex = igraph::list.vertex.attributes(x) )
+			network = igraph::graph_attr_names(x),
+			edge = igraph::edge_attr_names(x),
+			vertex = igraph::vertex_attr_names(x) )
 		rval <- switch( type,
-			network = lapply( nams, function(a) igraph::get.graph.attribute(x, a) ),
-			edge = lapply( nams, function(a) igraph::get.edge.attribute(x, a) ),
-			vertex = lapply( nams, function(a) igraph::get.vertex.attribute(x, a) ) )
+			network = lapply( nams, function(a) igraph::graph_attr(x, a) ),
+			edge = lapply( nams, function(a) igraph::edge_attr(x, a) ),
+			vertex = lapply( nams, function(a) igraph::vertex_attr(x, a) ) )
 		names(rval) <- nams
 		return(rval)
 	}

--- a/examples/exNetwork.R
+++ b/examples/exNetwork.R
@@ -37,36 +37,36 @@ g <- igraph::graph( c(2,1, 3,1, 4,1, 5,1, # star
 	 n=14, directed=TRUE)
 # add some vertex attributes
 vl <- letters[seq(1, vcount(g))]
-g <- igraph::set.vertex.attribute(g, "label", value=vl)
+g <- igraph::set_vertex_attr(g, "label", value=vl)
 # add some edge attributes
-m <- igraph::get.edgelist(g)
+m <- igraph::as_edgelist(g)
 l <- matrix(vl[m+1], ncol=2)
 el <- apply(l, 1, paste, collapse="")
-g <- igraph::set.edge.attribute(g, "label", value=el)
-g <- igraph::set.graph.attribute(g, "layout", igraph::layout.fruchterman.reingold)
+g <- igraph::set_edge_attr(g, "label", value=el)
+g <- igraph::set_graph_attr(g, "layout", igraph::layout_with_fr)
 rm(vl, l, m, el)
 exIgraph <- g
 
 # undirected igraph
 exIgraph2 <- igraph::as.undirected(exIgraph)
-exIgraph2 <- igraph::set.edge.attribute(exIgraph2, "label", 
-	value=igraph::get.edge.attribute(exIgraph, "label"))
+exIgraph2 <- igraph::set_edge_attr(exIgraph2, "label", 
+	value=igraph::edge_attr(exIgraph, "label"))
 
 
 # copy as a 'network' object through adjacency matrix
-m <- igraph::get.adjacency(exIgraph)
+m <- igraph::as_adjacency_matrix(exIgraph)
 g <- network::network(m, vertex.attr=list(label=vattr(exIgraph, "label")),
     vertex.attrnames="label", directed=TRUE)
 network::set.vertex.attribute(g, "vertex.names", value=vattr(exIgraph, "label"))
-network::set.edge.attribute(g, "label", igraph::get.edge.attribute(exIgraph, "label"))
+network::set.edge.attribute(g, "label", igraph::edge_attr(exIgraph, "label"))
 exNetwork <- network::network.copy(g)
 
 # copy as a 'network' object through adjacency matrix
-m <- igraph::get.adjacency(exIgraph2)
+m <- igraph::as_adjacency_matrix(exIgraph2)
 g <- network::network(m, vertex.attr=list(label=vattr(exIgraph2, "label")),
     vertex.attrnames="label", directed=FALSE)
 network::set.vertex.attribute(g, "vertex.names", value=vattr(exIgraph2, "label"))
-network::set.edge.attribute(g, "label", igraph::get.edge.attribute(exIgraph2, "label"))
+network::set.edge.attribute(g, "label", igraph::edge_attr(exIgraph2, "label"))
 exNetwork2 <- network::network.copy(g)
 }
 

--- a/examples/package-intergraph.R
+++ b/examples/package-intergraph.R
@@ -14,7 +14,7 @@ if( require(network) & require(igraph) )
   # check if 'exNetwork' and 'g' are the same
   # (dropping some aux attributes)
   all.equal( structure(as.matrix(exNetwork, "edgelist"), n=NULL, vnames=NULL),
-    igraph::get.edgelist(g) )   
+    igraph::as_edgelist(g) )   
 
   # compare results using 'netcompare'
   netcompare(exNetwork, g)

--- a/man/exNetwork.Rd
+++ b/man/exNetwork.Rd
@@ -76,36 +76,36 @@ g <- igraph::graph( c(2,1, 3,1, 4,1, 5,1, # star
 	 n=14, directed=TRUE)
 # add some vertex attributes
 vl <- letters[seq(1, vcount(g))]
-g <- igraph::set.vertex.attribute(g, "label", value=vl)
+g <- igraph::set_vertex_attr(g, "label", value=vl)
 # add some edge attributes
-m <- igraph::get.edgelist(g)
+m <- igraph::as_edgelist(g)
 l <- matrix(vl[m+1], ncol=2)
 el <- apply(l, 1, paste, collapse="")
-g <- igraph::set.edge.attribute(g, "label", value=el)
-g <- igraph::set.graph.attribute(g, "layout", igraph::layout.fruchterman.reingold)
+g <- igraph::set_edge_attr(g, "label", value=el)
+g <- igraph::set_graph_attr(g, "layout", igraph::layout_with_fr)
 rm(vl, l, m, el)
 exIgraph <- g
 
 # undirected igraph
 exIgraph2 <- igraph::as.undirected(exIgraph)
-exIgraph2 <- igraph::set.edge.attribute(exIgraph2, "label", 
-	value=igraph::get.edge.attribute(exIgraph, "label"))
+exIgraph2 <- igraph::set_edge_attr(exIgraph2, "label", 
+	value=igraph::edge_attr(exIgraph, "label"))
 
 
 # copy as a 'network' object through adjacency matrix
-m <- igraph::get.adjacency(exIgraph)
+m <- igraph::as_adjacency_matrix(exIgraph)
 g <- network::network(m, vertex.attr=list(label=vattr(exIgraph, "label")),
     vertex.attrnames="label", directed=TRUE)
 network::set.vertex.attribute(g, "vertex.names", value=vattr(exIgraph, "label"))
-network::set.edge.attribute(g, "label", igraph::get.edge.attribute(exIgraph, "label"))
+network::set.edge.attribute(g, "label", igraph::edge_attr(exIgraph, "label"))
 exNetwork <- network::network.copy(g)
 
 # copy as a 'network' object through adjacency matrix
-m <- igraph::get.adjacency(exIgraph2)
+m <- igraph::as_adjacency_matrix(exIgraph2)
 g <- network::network(m, vertex.attr=list(label=vattr(exIgraph2, "label")),
     vertex.attrnames="label", directed=FALSE)
 network::set.vertex.attribute(g, "vertex.names", value=vattr(exIgraph2, "label"))
-network::set.edge.attribute(g, "label", igraph::get.edge.attribute(exIgraph2, "label"))
+network::set.edge.attribute(g, "label", igraph::edge_attr(exIgraph2, "label"))
 exNetwork2 <- network::network.copy(g)
 }
 

--- a/man/intergraph-package.Rd
+++ b/man/intergraph-package.Rd
@@ -47,7 +47,7 @@ if( require(network) & require(igraph) )
   # check if 'exNetwork' and 'g' are the same
   # (dropping some aux attributes)
   all.equal( structure(as.matrix(exNetwork, "edgelist"), n=NULL, vnames=NULL),
-    igraph::get.edgelist(g) )   
+    igraph::as_edgelist(g) )   
 
   # compare results using 'netcompare'
   netcompare(exNetwork, g)

--- a/tests/testthat/test-asIgraph.R
+++ b/tests/testthat/test-asIgraph.R
@@ -24,7 +24,7 @@ test_that("Vertex names are properly set via 'vnames' argument for directed netw
   # existing column in 'vertices'
   l <- asDF(exIgraph)
   g <- asIgraph( l$edges, vertices=l$vertexes, vnames="label")
-  expect_equal( l$vertexes$label, igraph::get.vertex.attribute(g, "name"))
+  expect_equal( l$vertexes$label, igraph::vertex_attr(g, "name"))
 } )
 
 

--- a/tests/testthat/test-attrmap.R
+++ b/tests/testthat/test-attrmap.R
@@ -13,5 +13,5 @@ test_that("'na' vertex attribute can be dropped when going network->igraph", {
   )
   aa <- rbind(a, r)
   g <- asIgraph(net, amap=aa)
-  expect_false( "na" %in% igraph::list.vertex.attributes(g))
+  expect_false( "na" %in% igraph::vertex_attr_names(g))
 } )

--- a/tests/testthat/test-github_issues.R
+++ b/tests/testthat/test-github_issues.R
@@ -6,7 +6,7 @@ test_that("NAs are preserved in edge attributes", {
   net <- asNetwork(g)
   expect_true(any( is.na(network::get.edge.attribute(net, "label"))))
   ig <- asIgraph(net)
-  expect_true(any( is.na(igraph::get.edge.attribute(ig, "label"))))
+  expect_true(any( is.na(igraph::edge_attr(ig, "label"))))
 } )
 
 test_that("NAs are preserved in vertex attributes", {
@@ -15,5 +15,5 @@ test_that("NAs are preserved in vertex attributes", {
   net <- asNetwork(g)
   expect_true(any( is.na(network::get.vertex.attribute(net, "label"))))
   ig <- asIgraph(net)
-  expect_true(any( is.na(igraph::get.vertex.attribute(ig, "label"))))
+  expect_true(any( is.na(igraph::vertex_attr(ig, "label"))))
 } )

--- a/vignettes/howto.Rmd
+++ b/vignettes/howto.Rmd
@@ -192,8 +192,8 @@ Now we can use it with `asIgraph`:
 (ig2 <- asIgraph(exNetwork, amap=rules))
 
 # check if "na" was dropped
-"na" %in% igraph::list.vertex.attributes(ig1)
-"na" %in% igraph::list.vertex.attributes(ig2)
+"na" %in% igraph::vertex_attr_names(ig1)
+"na" %in% igraph::vertex_attr_names(ig2)
 ```
 
 


### PR DESCRIPTION
Part of this is required for the upcoming igraph 2.0.0, planning to send it to CRAN mid-January.

Upstream: https://github.com/igraph/rigraph/issues/989

CC @mbojan.